### PR TITLE
Automating imports

### DIFF
--- a/template/src/ontology/Makefile
+++ b/template/src/ontology/Makefile
@@ -59,7 +59,7 @@ seed.txt: $(SRC)
 # Should be able to drop this if robot can just take a big messy list of terms as input.
 
 imports/%_terms_combined.txt: seed.txt
-	grep -i $(OBO)/$*_$< | cat imports/%_terms.txt >  $@
+	cat $< imports/$*_terms.txt >  $@
 
 # Make this target to regenerate ALL
 all_imports: $(IMPORTS_OWL)

--- a/template/src/ontology/Makefile
+++ b/template/src/ontology/Makefile
@@ -49,13 +49,23 @@ $(ONT).obo: $(ONT).owl
 # These can be regenerated with make all_imports
 
 IMPORTS = MY_IMPORTS_LIST
-IMPORTS_OWL = $(patsubst %, imports/%_import.owl,$(IMPORTS)) $(patsubst %, imports/%_import.obo,$(IMPORTS))
+IMPORTS_OWL = $(patsubst %, imports/%_import.owl,$(IMPORTS)) $(patsubst %, imports/%_import.obo,$(IMPORTS)) $(patsubst %, imports/%_terms.txt,$(IMPORTS))
+
+# generate seed with all referenced entities
+seed.txt: $(SRC)
+	$(ROBOT) query -f csv -i $< --query ../sparql/terms.sparql $@
+
+# Generate terms.txt for each import.  # Assume OBO-style Possibly hacky step?
+# Should be able to drop this if robot can just take a big messy list of terms as input.
+
+imports/%_terms_combined.txt: seed.txt
+	grep -i $(OBO)/$*_$< | cat imports/%_terms.txt >  $@
 
 # Make this target to regenerate ALL
 all_imports: $(IMPORTS_OWL)
 
 # Use ROBOT, driven entirely by terms lists NOT from source ontology
-imports/%_import.owl: mirror/%.owl imports/%_terms.txt
+imports/%_import.owl: mirror/%.owl imports/%_terms_combined.txt
 	$(ROBOT) extract -i $< -T imports/$*_terms.txt --method BOT -O $(BASE)/$@ -o $@
 .PRECIOUS: imports/%_import.owl
 

--- a/template/src/sparql/terms.sparql
+++ b/template/src/sparql/terms.sparql
@@ -1,0 +1,7 @@
+SELECT DISTINCT ?term
+WHERE {
+  { ?s1 ?p1 ?term . }
+  UNION
+  { ?term ?p2 ?o2 . }
+  FILTER(isIRI(?term))
+}


### PR DESCRIPTION
 %_terms.txt for each imported ontology is merged with seed.txt which has all referenced terms.  In tests with FBbt earlier this year, this configuration work consistently with Robot.  Before merging this pull request, we should check that this does work using some real examples.  If not, submit a Robot bug report - but for quick fix also switch to filtering seed.txt for relevant terms before combining with manually edited.

FBbt does this with
``` make
	grep -i $(OBO)/$*_ $< > $@
```



